### PR TITLE
chore(flake/nixpkgs): `a119e218` -> `21321a63`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1655096306,
-        "narHash": "sha256-3B3zBaQVLL956deZgmucouvkZroObQ4JKHzbIfFS9/c=",
+        "lastModified": 1655910979,
+        "narHash": "sha256-vknkFY8AEA7aLdtvyQ3P+pPsp70w9XsDR6t4M94q9sI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a119e218ad27bea32057a3463e3694a61c9e3802",
+        "rev": "21321a6381fd8d3660fe1cdc0485fbb5978112ce",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
| [`09fc2817`](https://github.com/NixOS/nixpkgs/commit/09fc2817de83924dd5b758d7eab0a3409ac7ae25) | `crun: Don't use hard-coded /usr/bin paths`                                          |
| [`b461bd58`](https://github.com/NixOS/nixpkgs/commit/b461bd584d70c893696516c0f1e35b79aea2ac51) | `yt-dlp: 2022.05.18 -> 2022.6.22.1`                                                  |
| [`7e87f78f`](https://github.com/NixOS/nixpkgs/commit/7e87f78f0dec0c9bc186199bcb54a7cdcfa14280) | `salt: 3004.1 -> 3004.2`                                                             |
| [`7ca43ee1`](https://github.com/NixOS/nixpkgs/commit/7ca43ee102f87106191644deec8b3d3ade7bbea2) | `chromiumDev: 104.0.5110.0 -> 104.0.5112.12`                                         |
| [`ac331bfa`](https://github.com/NixOS/nixpkgs/commit/ac331bfa2e5f94cf11ad9bd90678d42e6ae6d7b2) | `chromiumBeta: 103.0.5060.42 -> 103.0.5060.53`                                       |
| [`78dddd85`](https://github.com/NixOS/nixpkgs/commit/78dddd850412bdc05654c60d38dc441844eaf1a6) | `chromiumDev: 104.0.5098.0 -> 104.0.5110.0`                                          |
| [`9248bfa1`](https://github.com/NixOS/nixpkgs/commit/9248bfa199ae515114337b41a3a15db7fc9c4895) | `chromiumBeta: 103.0.5060.33 -> 103.0.5060.42`                                       |
| [`3c16b789`](https://github.com/NixOS/nixpkgs/commit/3c16b789058cbafb2c805dd936aaebda7a1591f8) | `chromiumDev: 104.0.5083.0 -> 104.0.5098.0`                                          |
| [`496afda7`](https://github.com/NixOS/nixpkgs/commit/496afda7b49a42b71b77c6c81503b4602ec6c959) | `chromiumBeta: 103.0.5060.24 -> 103.0.5060.33`                                       |
| [`8f5a8317`](https://github.com/NixOS/nixpkgs/commit/8f5a83170d861dd70f12349f7193191a7879af40) | `chromiumDev: 103.0.5060.24 -> 104.0.5083.0`                                         |
| [`ff02616d`](https://github.com/NixOS/nixpkgs/commit/ff02616d85632b8c7600d0b2fdfa01ee317d3f41) | `chromiumBeta: 102.0.5005.61 -> 103.0.5060.24`                                       |
| [`f1a49923`](https://github.com/NixOS/nixpkgs/commit/f1a49923a11e8c34963ee52cdba6c8c27277a647) | `chromiumDev: 103.0.5060.13 -> 103.0.5060.24`                                        |
| [`b079f0c3`](https://github.com/NixOS/nixpkgs/commit/b079f0c39dc4ddb034b1568b7c59e30973809733) | `chromiumDev: 103.0.5056.0 -> 103.0.5060.13`                                         |
| [`95fc0b80`](https://github.com/NixOS/nixpkgs/commit/95fc0b8010abb1c5e9d9e2d2161211ebbc2d47e2) | `chromiumBeta: 102.0.5005.49 -> 102.0.5005.61`                                       |
| [`30d1a900`](https://github.com/NixOS/nixpkgs/commit/30d1a900b11367d672ea55f024033fb4c23332ae) | `gnome.aisleriot: 3.22.23 -> 3.22.24`                                                |
| [`03dea20f`](https://github.com/NixOS/nixpkgs/commit/03dea20f59c224ef9d9ce369af31f27e8e1fdeb5) | `eclipse.plugins.bytecode-outline: 2.5.0.201711011753-5a57fdf -> 1.0.1.202006062100` |
| [`bde79a89`](https://github.com/NixOS/nixpkgs/commit/bde79a8921f2daa0011e403d935dfe4ff39a38bf) | `eclipse.plugins.anyedittools: 2.7.1.201709201439 -> 2.7.2.202006062100`             |
| [`086ddfab`](https://github.com/NixOS/nixpkgs/commit/086ddfabba846b36ce7aa51443f1110df96ba736) | `doc/builders/images/dockertools: improve shadowSetup example`                       |
| [`68c0875c`](https://github.com/NixOS/nixpkgs/commit/68c0875cc54c44d3bc73bb82131fb295ca24af6a) | `anime-downloader: init at 5.0.14`                                                   |
| [`afad2ad6`](https://github.com/NixOS/nixpkgs/commit/afad2ad6e93f294cfbf2772377233360f59085c5) | `terraform: 1.2.2 -> 1.2.3`                                                          |
| [`4b4a0539`](https://github.com/NixOS/nixpkgs/commit/4b4a0539e190279f6c96c43f3d42054c10e6884f) | `archivebox: mark insecure`                                                          |
| [`87c4c082`](https://github.com/NixOS/nixpkgs/commit/87c4c082c6ddd2c7536fbd3557e1e340cf25128c) | `archivebox: update Django to 3.1.14`                                                |
| [`950b0574`](https://github.com/NixOS/nixpkgs/commit/950b0574fc27c090faf816ee02b0cd18700060ad) | `imagemagick: 7.1.0-37 -> 7.1.0-39`                                                  |
| [`71739af2`](https://github.com/NixOS/nixpkgs/commit/71739af235e5a098d5795c8a92aedd48ce201a91) | `dmd: Fix grep in test after gdb bump`                                               |
| [`65a9d22c`](https://github.com/NixOS/nixpkgs/commit/65a9d22c91569a7b128a35c6228fe6ff49e05e7c) | `boost: use jfrog mirror instead of bintray`                                         |
| [`c67f5e4e`](https://github.com/NixOS/nixpkgs/commit/c67f5e4e20e0f6623dfeac672e04bded1cc64965) | `strace: 5.17 -> 5.18`                                                               |
| [`44b7a871`](https://github.com/NixOS/nixpkgs/commit/44b7a871b160a7154404d749830a1fc963f29b6f) | `nixos/pipewire: fix wireplumber with system-wide`                                   |
| [`bc3470c3`](https://github.com/NixOS/nixpkgs/commit/bc3470c3828b0ffabaff37af781ecfc25079574f) | `clang-tools: provide many versions`                                                 |
| [`d93a5bd1`](https://github.com/NixOS/nixpkgs/commit/d93a5bd1551ca293a92fa07822aafcfc2b0e1be9) | `clang-tools: don't hardcode list of tools`                                          |
| [`269dd1ea`](https://github.com/NixOS/nixpkgs/commit/269dd1ea6abf0c9e3477482e7bfda3cd689a7433) | `ipe: 7.2.23 -> 7.2.24`                                                              |
| [`2990bf77`](https://github.com/NixOS/nixpkgs/commit/2990bf771eb0912adaca06b9cdbbeff8e3e7d7d4) | `jbake: 2.6.5 -> 2.6.7`                                                              |
| [`f1603cb4`](https://github.com/NixOS/nixpkgs/commit/f1603cb4db16323fd2c1a1f5ad27f10e7dec3fa8) | `asciidoctorj: 2.4.2 -> 2.5.4`                                                       |
| [`d423c0ce`](https://github.com/NixOS/nixpkgs/commit/d423c0ce15adf573c2045bef5c921b958b674bb4) | `pkgsStatic.libunwind: fix build`                                                    |
| [`b7bd07ef`](https://github.com/NixOS/nixpkgs/commit/b7bd07ef8dc624f51737ba8957ad4e90e05c72b3) | `tor: 0.4.7.7 -> 0.4.7.8`                                                            |
| [`171ae679`](https://github.com/NixOS/nixpkgs/commit/171ae679085ed969e0cd9066b35d34b1a0b2b60f) | `strawberry: 1.0.4 -> 1.0.5`                                                         |
| [`e647b323`](https://github.com/NixOS/nixpkgs/commit/e647b323093ac309c610fbec76a2285c5d64bb27) | `github-runner: 2.292.0 -> 2.293.0`                                                  |
| [`5d3d42e0`](https://github.com/NixOS/nixpkgs/commit/5d3d42e0675fc93c811712f20c523efdcce7316f) | `unclutter-xfixes: fix cross-compilation`                                            |
| [`13ccaac7`](https://github.com/NixOS/nixpkgs/commit/13ccaac700e5d05a9a551e3fa15a40b4b65e5c91) | `pantheon.elementary-files: 6.1.2 -> 6.1.3`                                          |
| [`cc6a0436`](https://github.com/NixOS/nixpkgs/commit/cc6a0436b5f56df79e2c50b8589c4911711a71a2) | `netdata: 1.34.1 -> 1.35.1`                                                          |
| [`4b1707c3`](https://github.com/NixOS/nixpkgs/commit/4b1707c38e05cb355ff0bf25fb52dbfcea1c0f09) | `lowdown: 0.11.1 -> 1.0.0`                                                           |
| [`02257c62`](https://github.com/NixOS/nixpkgs/commit/02257c62a217cff4beb8fcd08cb19aaed3fec164) | `calamares-nixos-extensions: 0.3.8 -> 0.3.10`                                        |
| [`a17a3845`](https://github.com/NixOS/nixpkgs/commit/a17a3845ad9cc997e9592c2e25a2d33b4e1eea5e) | `installation-cd: prevent gnome from sleeping`                                       |
| [`bd8749bc`](https://github.com/NixOS/nixpkgs/commit/bd8749bcc194fe124f7316bfe4587a8bf84160c8) | `calamares: increase default verbosity`                                              |
| [`91e813ba`](https://github.com/NixOS/nixpkgs/commit/91e813ba57d6b90c0d47a32a758fe6bf5f135511) | `calamares: 3.2.57 -> 3.2.59`                                                        |
| [`2f361cb7`](https://github.com/NixOS/nixpkgs/commit/2f361cb7e75a9e05d98a37ac70d7c69fbc57e142) | `hydrus: 483 -> 488d (#177770)`                                                      |
| [`721e822a`](https://github.com/NixOS/nixpkgs/commit/721e822a1fc66307e7ebd492c2893ca03470ccaf) | `groovy: 3.0.7 -> 3.0.11`                                                            |
| [`10ebb731`](https://github.com/NixOS/nixpkgs/commit/10ebb731ee93dbdeab08a4963305fb482eb129e1) | `calibre: fix chm processing dependency`                                             |
| [`354b2a0b`](https://github.com/NixOS/nixpkgs/commit/354b2a0b680a36debc9a76a139a12e48a406feae) | `pythonPackages.pychm,python3Packages.pychm: init at 0.8.6`                          |
| [`50d63d16`](https://github.com/NixOS/nixpkgs/commit/50d63d1664f572981430fc7ed15088440e3bc33b) | `mailmanPackages.hyperkitty: fix build`                                              |
| [`e5366801`](https://github.com/NixOS/nixpkgs/commit/e5366801dc80a9feaceb2656d16dd704b1c8f3f3) | `kdigger: init at 1.2.0`                                                             |
| [`5a9a5c54`](https://github.com/NixOS/nixpkgs/commit/5a9a5c545fbc15aed258db8210e1657380965d32) | `vscode: 1.68.0 -> 1.68.1`                                                           |
| [`04574484`](https://github.com/NixOS/nixpkgs/commit/04574484d889651b28e0d0ed9c3ea6abb6932d9d) | `vscodium: 1.68.0 -> 1.68.1`                                                         |
| [`8926e9d7`](https://github.com/NixOS/nixpkgs/commit/8926e9d73e02f1f91d688252623576d676434633) | `gollum: fix shebang in bin/gollum`                                                  |
| [`902a2521`](https://github.com/NixOS/nixpkgs/commit/902a25219ab7b46fd08ca1350a740110cbd7c7da) | `nixos/gollum: add option local-time`                                                |
| [`fab1014e`](https://github.com/NixOS/nixpkgs/commit/fab1014ef33271129f529d39d6e231e411fbd131) | `nixos/gollum: improve description of user-icons option`                             |
| [`79f48e6b`](https://github.com/NixOS/nixpkgs/commit/79f48e6beba3e2f7747f3f472c0ba616a36d4e88) | `gollum: 5.2.3 → 5.3.0`                                                              |
| [`10065cfb`](https://github.com/NixOS/nixpkgs/commit/10065cfbfc17b4e78affa14a53210d7890a4c1f7) | `linuxPackages.system76-io: 1.0.1 -> 1.0.2`                                          |
| [`b389f332`](https://github.com/NixOS/nixpkgs/commit/b389f332aed224e4887453c7880ba5f32354dd24) | `conftest: 0.32.0 -> 0.32.1`                                                         |
| [`a4fa9496`](https://github.com/NixOS/nixpkgs/commit/a4fa94965acf7b15d15816f5705d43e6afd08447) | `python3Packages.pytorch: unbreak on Darwin`                                         |
| [`c7c2ff3f`](https://github.com/NixOS/nixpkgs/commit/c7c2ff3fc8ac3258ca6dd333b3af7be333e33f16) | `mautrix-whatsapp: 0.4.0 -> 0.5.0`                                                   |
| [`527e23dd`](https://github.com/NixOS/nixpkgs/commit/527e23dde7ba7e32cea24d1ea976ab0824ae9195) | `palemoon: Limit build cores count`                                                  |
| [`26f77c9c`](https://github.com/NixOS/nixpkgs/commit/26f77c9cf77c6b9e3ae29902fc30af4275b615cb) | `element-{web,desktop}: 1.10.14 -> 1.10.15`                                          |
| [`ed4228ce`](https://github.com/NixOS/nixpkgs/commit/ed4228ceee8fdbc69648f00e23e54f03398b9af3) | `signal-desktop: 5.45.1 -> 5.46.0`                                                   |
| [`8eca7704`](https://github.com/NixOS/nixpkgs/commit/8eca77048d95c0289447f210ac591254da24a1fa) | `python3: fix wrong platform libs when cross-compiling`                              |
| [`f649e167`](https://github.com/NixOS/nixpkgs/commit/f649e16704137339fdb0626d3091f4ac78362a6b) | `linux/hardened/patches/5.4: 5.4.197-hardened1 -> 5.4.198-hardened1`                 |
| [`88a0136f`](https://github.com/NixOS/nixpkgs/commit/88a0136f69fbea14f5beae9e06a29c76bf91c8d9) | `linux/hardened/patches/5.17: 5.17.14-hardened1 -> 5.17.15-hardened1`                |
| [`6bfdb41e`](https://github.com/NixOS/nixpkgs/commit/6bfdb41e73e32dbe6cd42bd9195feda905c5d1c4) | `linux/hardened/patches/5.15: 5.15.46-hardened1 -> 5.15.47-hardened1`                |
| [`d8c152db`](https://github.com/NixOS/nixpkgs/commit/d8c152db08b49e1ae9a779352db1e7c9258bbee3) | `linux/hardened/patches/5.10: 5.10.121-hardened1 -> 5.10.122-hardened1`              |
| [`efba3d13`](https://github.com/NixOS/nixpkgs/commit/efba3d1342bd02d860ca1b42530b2e4c284000c1) | `linux/hardened/patches/4.19: 4.19.246-hardened1 -> 4.19.247-hardened1`              |
| [`b822cca8`](https://github.com/NixOS/nixpkgs/commit/b822cca8bb704b8f9855c98467c5acffe98dd5d6) | `linux/hardened/patches/4.14: 4.14.282-hardened1 -> 4.14.283-hardened1`              |
| [`f616afaa`](https://github.com/NixOS/nixpkgs/commit/f616afaabd6515f5eadeff0ef795c5fa232a0faa) | `linux: 5.4.197 -> 5.4.198`                                                          |
| [`a415091c`](https://github.com/NixOS/nixpkgs/commit/a415091c5cb82fb4cebb7af317068d8825386902) | `linux: 5.18.3 -> 5.18.4`                                                            |
| [`9d7625ac`](https://github.com/NixOS/nixpkgs/commit/9d7625ac978ec765822bddcda06b3b78c4e1b88d) | `linux: 5.17.14 -> 5.17.15`                                                          |
| [`ffed955b`](https://github.com/NixOS/nixpkgs/commit/ffed955bca6b502c021f6dc6027d99507280a2e5) | `linux: 5.15.46 -> 5.15.47`                                                          |
| [`07149c1a`](https://github.com/NixOS/nixpkgs/commit/07149c1a36cd43579be7c9fac238d57fb85023ac) | `linux: 5.10.121 -> 5.10.122`                                                        |
| [`76fc882e`](https://github.com/NixOS/nixpkgs/commit/76fc882e48d75071b3cea34a24e9c91e399394dc) | `linux: 4.9.317 -> 4.9.318`                                                          |
| [`435237e5`](https://github.com/NixOS/nixpkgs/commit/435237e5663b276c6f445ccd9839a0091cc60f95) | `linux: 4.19.246 -> 4.19.247`                                                        |
| [`27e5a202`](https://github.com/NixOS/nixpkgs/commit/27e5a2023788eac3c1dfe678e89d451f8b7c42a4) | `linux: 4.14.282 -> 4.14.283`                                                        |
| [`9a9042bf`](https://github.com/NixOS/nixpkgs/commit/9a9042bfbfa3e801c888bf9238e672c7c5a32837) | `networkmanager: 1.38.0 -> 1.38.2`                                                   |
| [`d6a81a74`](https://github.com/NixOS/nixpkgs/commit/d6a81a748a4cdd933710ebdad6e345fda2d2b647) | `graalvmXX-ce: use a patched version of zlib`                                        |
| [`9fb4d487`](https://github.com/NixOS/nixpkgs/commit/9fb4d4874b32f580b1e76593b53a14fe0575cd41) | `pdns-recursor: 4.6.2 -> 4.7.0`                                                      |
| [`be6bb5e5`](https://github.com/NixOS/nixpkgs/commit/be6bb5e5d37259963f7f07005df18b079bd210e1) | `grafana: 8.5.5 -> 8.5.6`                                                            |
| [`bc8d4130`](https://github.com/NixOS/nixpkgs/commit/bc8d41309794a24c03a6854cc6b9efc8af156e08) | `linuxPackages.system76-io: Fix building on newer kernels.`                          |
| [`f3b2cf83`](https://github.com/NixOS/nixpkgs/commit/f3b2cf835ed64b26d3e7bb0524d2f06915682fc5) | `matrix-synapse: 1.60.0 -> 1.61.0`                                                   |
| [`f27eb9db`](https://github.com/NixOS/nixpkgs/commit/f27eb9dba1b25d54b09b130739cabebced4351c0) | `nixVersions.nix_2_9: pull patch to add missing git-dir flags`                       |
| [`713b7b04`](https://github.com/NixOS/nixpkgs/commit/713b7b04045268f155dc27b3a5e42ec3fef09104) | `ocamlPackages.wasm: 1.1.1 → 2.0.0`                                                  |
| [`a4f5b169`](https://github.com/NixOS/nixpkgs/commit/a4f5b169f1e40aba9fd2eedcc6ebba3e9f90645e) | `liblouis: apply patch for CVE-2022-26981`                                           |
| [`53625a5a`](https://github.com/NixOS/nixpkgs/commit/53625a5a9133e6d1ea5e27b5ae2077665a90c477) | `pantheon.elementary-settings-daemon: add updateScript`                              |
| [`42035d4f`](https://github.com/NixOS/nixpkgs/commit/42035d4f46f56a74d9a64c81d0e126e3c7b059b6) | `pantheon.elementary-notifications: add updateScript`                                |
| [`39f94f1f`](https://github.com/NixOS/nixpkgs/commit/39f94f1f9f2501987e5306cc0696d1e175a9c303) | `pantheon.switchboard: 6.0.1 -> 6.0.2`                                               |
| [`edfe3cca`](https://github.com/NixOS/nixpkgs/commit/edfe3cca168743b76cbc9b10fad8782018211e18) | `pantheon.elementary-tasks: 6.2.0 -> 6.3.0`                                          |
| [`891d2bdc`](https://github.com/NixOS/nixpkgs/commit/891d2bdc0bba57e5778344f262e187a8f7583895) | `scala-cli: 0.1.7 -> 0.1.8`                                                          |
| [`803e6c05`](https://github.com/NixOS/nixpkgs/commit/803e6c05eee6831097ed0741505ebb079a954161) | `podman: 4.1.0 -> 4.1.1`                                                             |
| [`6eacd249`](https://github.com/NixOS/nixpkgs/commit/6eacd249e683396a505a1def5117f086802a4fc4) | `chain-bench: init at 0.0.2`                                                         |
| [`761b7375`](https://github.com/NixOS/nixpkgs/commit/761b7375504200c0f08e065d59f6ebbbb3ca425b) | `scala-cli: 0.1.6 -> 0.1.7`                                                          |
| [`c385762f`](https://github.com/NixOS/nixpkgs/commit/c385762fbc06fa69d283b9f0c91515d5ecb189f1) | `gnome.gnome-calendar: 42.1 -> 42.2`                                                 |
| [`7bc04740`](https://github.com/NixOS/nixpkgs/commit/7bc04740c74eb7520eee2eb62cd78ff3db73c423) | `gtksourceview5: 5.4.1 -> 5.4.2`                                                     |
| [`0f96caf1`](https://github.com/NixOS/nixpkgs/commit/0f96caf132e2347db2d606d8cff9f2d803906e08) | `gnome.ghex: 42.2 -> 42.3`                                                           |
| [`09319c57`](https://github.com/NixOS/nixpkgs/commit/09319c570a7696edc019fd5de20f961c493e3ea0) | `gnome-text-editor: 42.1 -> 42.2`                                                    |
| [`99236dc3`](https://github.com/NixOS/nixpkgs/commit/99236dc3f92db9d61f411ff3aa058233f84b9310) | `mkvtoolnix: 67.0.0 -> 68.0.0`                                                       |
| [`c9c05870`](https://github.com/NixOS/nixpkgs/commit/c9c05870f56e2f406d5815b5564c410fbe6c0d90) | `vscodium: 1.67.2 -> 1.68.0`                                                         |
| [`aab59afe`](https://github.com/NixOS/nixpkgs/commit/aab59afec11d88e9cee5b7a73561166d9b151700) | `ft2-clone: 1.54 -> 1.55`                                                            |
| [`8da987d8`](https://github.com/NixOS/nixpkgs/commit/8da987d804ab54ddc819e39479aa6d578b0191e1) | `go-ethereum: 1.10.17 -> 1.10.18`                                                    |
| [`598e9baf`](https://github.com/NixOS/nixpkgs/commit/598e9baf7d86ed582e67075c6f201ce4d6d866bd) | `dovecot: 2.3.19 -> 2.3.19.1`                                                        |
| [`a02bbf01`](https://github.com/NixOS/nixpkgs/commit/a02bbf01ecd3a75738746ef09d94178857014e33) | `matcha-gtk-theme: 2021-12-25 -> 2022-06-07`                                         |
| [`ad1a4528`](https://github.com/NixOS/nixpkgs/commit/ad1a4528140afc50fb4730ea054cf3184632c0bf) | `matcha-gtk-theme: add update script`                                                |
| [`95264632`](https://github.com/NixOS/nixpkgs/commit/95264632ae8e3f5dac6ef101386f9de618413db5) | `matcha-gtk-theme: reformat nix expression`                                          |
| [`807db9e5`](https://github.com/NixOS/nixpkgs/commit/807db9e5e8358f6efc14fc6f8b677097a3d9e5e6) | `submitting-changes.chapter.md: avoid being specific`                                |
| [`463675ef`](https://github.com/NixOS/nixpkgs/commit/463675efd78bf9cc03ab1bf7b1f56dfa687f6e40) | `submitting-changes.chapter.md: explain that purple arrows are manual`               |
| [`d7b4ced4`](https://github.com/NixOS/nixpkgs/commit/d7b4ced4b65cb686c5b93680adbb4bed9b8ea547) | `rnix-lsp: 0.2.4 -> 0.2.5`                                                           |
| [`fdaefd3e`](https://github.com/NixOS/nixpkgs/commit/fdaefd3ea2a511ed5b1237757125fc629089a09a) | `tor-browser-bundle-bin: 11.0.13 -> 11.0.14`                                         |
| [`347f458b`](https://github.com/NixOS/nixpkgs/commit/347f458bbb840642e1adca7cb8721d039513adbe) | `stdenv/adapters.nix: Fix for overlay style arguments`                               |
| [`5afd4c96`](https://github.com/NixOS/nixpkgs/commit/5afd4c9683d4243ddf2726839584483776624ab0) | `palemoon: 31.0.0 -> 31.1.0`                                                         |
| [`1f2b6e8b`](https://github.com/NixOS/nixpkgs/commit/1f2b6e8bb71ed22f439f2069edf3b1ad4e2b28d6) | `element-{web,desktop}: 1.10.13 -> 1.10.14`                                          |
| [`ebcf4a97`](https://github.com/NixOS/nixpkgs/commit/ebcf4a97613a96ef55f128c4eaaf3da39715b830) | `yandex-browser: 22.1.3.907-1 -> 22.5.0.1879-1`                                      |
| [`041ac28b`](https://github.com/NixOS/nixpkgs/commit/041ac28bb534c30e4502cb4bbe0d403a834e586e) | `nixos/openldap: fix systemd rejecting notification (#177520)`                       |
| [`2524e4f9`](https://github.com/NixOS/nixpkgs/commit/2524e4f964cc1fc9b3cc8a5f5fc0577e045eb2de) | `apache-jena: 4.4.0 -> 4.5.0`                                                        |
| [`9b2957ee`](https://github.com/NixOS/nixpkgs/commit/9b2957ee4b5dd13c0a4f40bad4d32f19267fe7a2) | `mpd: fix socket activation`                                                         |
| [`4040a70b`](https://github.com/NixOS/nixpkgs/commit/4040a70b3585cf95a276fde20cfc9bc2edcc71f7) | `hydroxide: 0.2.21 -> 0.2.23`                                                        |
| [`0436580c`](https://github.com/NixOS/nixpkgs/commit/0436580cf1c96c393e1adc0caa6d6b9e58aaf404) | `nixUnstable: switch to the latest release`                                          |
| [`13f2106b`](https://github.com/NixOS/nixpkgs/commit/13f2106bf802fd3adbfbbfdc676613968f21e842) | `nixVersions.nix_2_9: 2.9.0 -> 2.9.1`                                                |
| [`a95318ac`](https://github.com/NixOS/nixpkgs/commit/a95318ac8700eeefd4610775b92580cc944ed0f3) | `nixVersions.nix_2_9: init at 2.9.0`                                                 |
| [`25b51afd`](https://github.com/NixOS/nixpkgs/commit/25b51afd963d144a9300207a6ff04d7c15b855ba) | `fwupd: 1.8.0 -> 1.8.1`                                                              |
| [`39e1db0c`](https://github.com/NixOS/nixpkgs/commit/39e1db0c739356a461ce2521229309db07949765) | `libxmlb: 0.3.8 -> 0.3.9`                                                            |
| [`49e42737`](https://github.com/NixOS/nixpkgs/commit/49e4273716d528d2d801cd09673a42df1a52050f) | `poppler: 22.04.0 -> 22.06.0`                                                        |
| [`adc9804e`](https://github.com/NixOS/nixpkgs/commit/adc9804e82e6630f4a132559337224f43b5519fb) | `drawio: 18.1.3 -> 19.0.2`                                                           |
| [`df8a72b1`](https://github.com/NixOS/nixpkgs/commit/df8a72b1f294ee804c18e04b35657a0662dbae21) | `github-runner: 2.291.1 -> 2.292.0`                                                  |
| [`e0b17fd4`](https://github.com/NixOS/nixpkgs/commit/e0b17fd48c44aa89f5e874389fe602d95cff2cc7) | `Mark dotnet unbroken`                                                               |
| [`57da584e`](https://github.com/NixOS/nixpkgs/commit/57da584e6ff934bba1fc5f0b9c6c85c82efe053c) | `deadbeef-statusnotifier-plugin: fix libdbusmenu dependency`                         |
| [`74d1c336`](https://github.com/NixOS/nixpkgs/commit/74d1c336ae4d25d3c61f0d50cd8ef1c0b57984f8) | `nixos/peertube: use redis.servers`                                                  |
| [`d5560931`](https://github.com/NixOS/nixpkgs/commit/d556093191e2c991abae4a97a6fb4cf087c5b015) | `kitty: 0.25.0 -> 0.25.1`                                                            |
| [`3d573b3f`](https://github.com/NixOS/nixpkgs/commit/3d573b3f00ed903363d37f7d1ba45af1a8651a03) | `nixos/nextcloud: Fix broken config file`                                            |